### PR TITLE
[STEP-14] RedisQueue 변경

### DIFF
--- a/src/main/java/kr/hhplus/be/server/api/token/TokenController.java
+++ b/src/main/java/kr/hhplus/be/server/api/token/TokenController.java
@@ -2,8 +2,10 @@ package kr.hhplus.be.server.api.token;
 
 import kr.hhplus.be.server.api.token.dto.SwaggerTokenController;
 import kr.hhplus.be.server.api.token.dto.TokenResponse;
+import kr.hhplus.be.server.api.token.dto.WaitingQueueResponse;
 import kr.hhplus.be.server.application.ConcertQueueTokenFacade;
 import kr.hhplus.be.server.application.dto.QueueTokenInfo;
+import kr.hhplus.be.server.domain.token.service.QueueService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TokenController implements SwaggerTokenController {
 
     private final ConcertQueueTokenFacade concertQueueTokenFacade;
+    private final QueueService queueService;
 
     @GetMapping("/tokens/{userId}/{concertId}")
     public ResponseEntity<TokenResponse> issueServiceToken(
@@ -23,6 +26,14 @@ public class TokenController implements SwaggerTokenController {
     ){
         QueueTokenInfo queueTokenInfo = concertQueueTokenFacade.issueQueueToken(userId, concertId);
         return ResponseEntity.ok(TokenResponse.of(queueTokenInfo.queueTokenId(), queueTokenInfo.expiresAt()));
+    }
+
+    @GetMapping("/waitingQueue/{userId}")
+    public ResponseEntity<WaitingQueueResponse> waitingQueue(
+            @PathVariable Long userId
+    ){
+        Long rank = queueService.addWaitingQueue(String.valueOf(userId));
+        return ResponseEntity.ok(WaitingQueueResponse.of(userId, rank));
     }
 
 }

--- a/src/main/java/kr/hhplus/be/server/api/token/TokenController.java
+++ b/src/main/java/kr/hhplus/be/server/api/token/TokenController.java
@@ -28,11 +28,12 @@ public class TokenController implements SwaggerTokenController {
         return ResponseEntity.ok(TokenResponse.of(queueTokenInfo.queueTokenId(), queueTokenInfo.expiresAt()));
     }
 
-    @GetMapping("/waitingQueue/{userId}")
+    @GetMapping("/waitingQueue/{userId}/{concertId}")
     public ResponseEntity<WaitingQueueResponse> waitingQueue(
-            @PathVariable Long userId
+            @PathVariable Long userId,
+            @PathVariable Long concertId
     ){
-        Long rank = queueService.addWaitingQueue(String.valueOf(userId));
+        Long rank = queueService.addWaitingQueue(String.valueOf(userId),String.valueOf(concertId));
         return ResponseEntity.ok(WaitingQueueResponse.of(userId, rank));
     }
 

--- a/src/main/java/kr/hhplus/be/server/api/token/dto/WaitingQueueResponse.java
+++ b/src/main/java/kr/hhplus/be/server/api/token/dto/WaitingQueueResponse.java
@@ -1,0 +1,25 @@
+package kr.hhplus.be.server.api.token.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class WaitingQueueResponse {
+
+    @Schema(description = "유저 ID ")
+    private long userId;
+
+    @Schema(description = "대기 순서")
+    private long rank;
+
+    private WaitingQueueResponse(long userId, long rank) {
+        this.userId = userId;
+        this.rank = rank;
+    }
+
+    public static WaitingQueueResponse of(long userId, long rank) {
+        return new WaitingQueueResponse(userId,rank);
+    }
+
+
+}

--- a/src/main/java/kr/hhplus/be/server/domain/concert/model/ConcertSchedule.java
+++ b/src/main/java/kr/hhplus/be/server/domain/concert/model/ConcertSchedule.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.domain.concert.model;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -28,6 +29,7 @@ public class ConcertSchedule extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "concert_id")
+    @JsonIgnore
     private Concert concert;
 
     private LocalDateTime concertDate;

--- a/src/main/java/kr/hhplus/be/server/domain/token/service/QueueService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/token/service/QueueService.java
@@ -1,6 +1,9 @@
 package kr.hhplus.be.server.domain.token.service;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,9 +26,19 @@ public class QueueService {
     }
 
     // 대기열에 추가
-    public Long addWaitingQueue(String userId) {
+    public Long addWaitingQueue(String userId, String concertId) {
+        String queueTokenId = UUID.randomUUID().toString();
         long score = System.currentTimeMillis();
         redisTemplate.opsForZSet().add(WAITING_TOKENS_KEY, userId, score);
+
+        Map<String, String> tokenData = new HashMap<>();
+        tokenData.put("userId", userId);
+        tokenData.put("enqueuedAt", String.valueOf(score));
+        tokenData.put("status", "ENQUEUED");
+        tokenData.put("concertId", concertId);
+
+        redisTemplate.opsForHash().putAll("token:" + queueTokenId, tokenData);
+
         return getWaitingRank(userId);
     }
 

--- a/src/main/java/kr/hhplus/be/server/domain/token/service/QueueService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/token/service/QueueService.java
@@ -1,0 +1,78 @@
+package kr.hhplus.be.server.domain.token.service;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+public class QueueService {
+
+    private static final String WAITING_TOKENS_KEY = "waiting-tokens";
+    private static final String ACTIVE_TOKENS_KEY = "active-tokens";
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    public QueueService(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    // 대기열에 추가
+    public Long addWaitingQueue(String userId) {
+        long score = System.currentTimeMillis();
+        redisTemplate.opsForZSet().add(WAITING_TOKENS_KEY, userId, score);
+        return getWaitingRank(userId);
+    }
+
+    public Long getWaitingRank(String userId) {
+        Long rank = redisTemplate.opsForZSet().rank(WAITING_TOKENS_KEY, userId);
+        if (rank != null) {
+            return rank + 1;
+        } else {
+            throw new IllegalStateException("현재 순위를 가져올 수 없습니다.");
+        }
+    }
+
+    // 활성으로 이동
+    public Set<String> transferWaitingToActive(int count) {
+        Set<ZSetOperations.TypedTuple<String>> tokens = redisTemplate.opsForZSet().popMin(WAITING_TOKENS_KEY, count);
+        Set<String> userIds = tokens.stream()
+                .map(ZSetOperations.TypedTuple::getValue)
+                .collect(Collectors.toSet());
+
+        if (!userIds.isEmpty()) {
+            for (String userId : userIds) {
+                addActiveQueue(userId, 600); // 10분 TTL
+            }
+        }
+        return userIds;
+    }
+
+    // 활성화 토큰에 TTL 설정하여 추가
+    public void addActiveQueue(String userId, long ttlSeconds) {
+        String key = "active-token:" + userId;
+        redisTemplate.opsForValue().set(key, "active", ttlSeconds, TimeUnit.SECONDS);
+        redisTemplate.opsForSet().add(ACTIVE_TOKENS_KEY, userId);
+    }
+
+    @Scheduled(fixedDelay = 60000)
+    public void removeExpiredActiveQueue() {
+        Set<String> activeTokens = redisTemplate.opsForSet().members(ACTIVE_TOKENS_KEY);
+        if (activeTokens != null) {
+            for (String userId : activeTokens) {
+                String key = "active-token:" + userId;
+                Boolean exists = redisTemplate.hasKey(key);
+                if (exists != null && !exists) {
+                    redisTemplate.opsForSet().remove(ACTIVE_TOKENS_KEY, userId);
+                }
+            }
+        }
+
+    }
+
+}

--- a/src/test/java/kr/hhplus/be/server/api/token/TokenControllerTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/token/TokenControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.time.LocalDateTime;
 import kr.hhplus.be.server.application.ConcertQueueTokenFacade;
 import kr.hhplus.be.server.application.dto.QueueTokenInfo;
+import kr.hhplus.be.server.domain.token.service.QueueService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +24,9 @@ class TokenControllerTest {
 
     @MockitoBean
     private ConcertQueueTokenFacade concertQueueTokenFacade;
+
+    @MockitoBean
+    private QueueService queueService;
 
     @DisplayName("토큰 발급한다. TokenResponse 리턴")
     @Test
@@ -42,6 +46,20 @@ class TokenControllerTest {
                 .andExpect(jsonPath("$.tokenId").value(queueTokenId));
     }
 
+    @DisplayName("대기열을 등록한다. WaitingQueueResponse 리턴")
+    @Test
+    void waitingQueueRankResponse() throws Exception {
+        // given
+        long userId = 1L;
+        Long rank = 2L;
 
+        when(queueService.addWaitingQueue(String.valueOf(userId))).thenReturn(rank);
+
+        // when // then
+        mockMvc.perform(get("/waitingQueue/{userId}", userId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(userId))
+                .andExpect(jsonPath("$.rank").value(rank));
+    }
 
 }

--- a/src/test/java/kr/hhplus/be/server/api/token/TokenControllerTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/token/TokenControllerTest.java
@@ -51,12 +51,13 @@ class TokenControllerTest {
     void waitingQueueRankResponse() throws Exception {
         // given
         long userId = 1L;
+        long concertId = 2L;
         Long rank = 2L;
 
-        when(queueService.addWaitingQueue(String.valueOf(userId))).thenReturn(rank);
+        when(queueService.addWaitingQueue(String.valueOf(userId),String.valueOf(concertId))).thenReturn(rank);
 
         // when // then
-        mockMvc.perform(get("/waitingQueue/{userId}", userId))
+        mockMvc.perform(get("/waitingQueue/{userId}/{concertId}", userId,concertId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.userId").value(userId))
                 .andExpect(jsonPath("$.rank").value(rank));

--- a/src/test/java/kr/hhplus/be/server/domain/token/service/QueueServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/token/service/QueueServiceTest.java
@@ -34,9 +34,10 @@ class QueueServiceTest {
     void testAddTokenToWaitingQueue() {
         // given
         String userId = "user1";
+        String concertId = "concert1";
 
         // when
-        queueService.addWaitingQueue(userId);
+        queueService.addWaitingQueue(userId,concertId);
 
         // then
         Double score = redisTemplate.opsForZSet().score("waiting-tokens", userId);
@@ -47,8 +48,8 @@ class QueueServiceTest {
     @Test
     void testTransferTokensToActive() {
         // given
-        queueService.addWaitingQueue("user1");
-        queueService.addWaitingQueue("user2");
+        queueService.addWaitingQueue("user1","concert1");
+        queueService.addWaitingQueue("user2","concert2");
 
         // when
         Set<String> activatedUsers = queueService.transferWaitingToActive(2);
@@ -64,15 +65,14 @@ class QueueServiceTest {
 
     }
 
-
     @DisplayName("대기열 진입 후 순위 확인")
     @Test
     void GetWaitingRank() {
         // given
         String userId1 = "user1";
         String userId2 = "user2";
-        queueService.addWaitingQueue(userId1);
-        queueService.addWaitingQueue(userId2);
+        queueService.addWaitingQueue(userId1,"concert1");
+        queueService.addWaitingQueue(userId2,"concert2");
 
         // when
         Long rank1 = queueService.getWaitingRank(userId1);

--- a/src/test/java/kr/hhplus/be/server/domain/token/service/QueueServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/token/service/QueueServiceTest.java
@@ -1,0 +1,104 @@
+package kr.hhplus.be.server.domain.token.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@RunWith(SpringRunner.class)
+@ActiveProfiles("test")
+@Testcontainers
+class QueueServiceTest {
+
+    @Autowired
+    private QueueService queueService;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+
+    @DisplayName("대기열 진입 확인")
+    @Test
+    void testAddTokenToWaitingQueue() {
+        // given
+        String userId = "user1";
+
+        // when
+        queueService.addWaitingQueue(userId);
+
+        // then
+        Double score = redisTemplate.opsForZSet().score("waiting-tokens", userId);
+        assertNotNull(score);
+    }
+
+    @DisplayName("테스트 전환")
+    @Test
+    void testTransferTokensToActive() {
+        // given
+        queueService.addWaitingQueue("user1");
+        queueService.addWaitingQueue("user2");
+
+        // when
+        Set<String> activatedUsers = queueService.transferWaitingToActive(2);
+
+        // then
+        assertEquals(2, activatedUsers.size());
+        assertTrue(activatedUsers.contains("user1"));
+        assertTrue(activatedUsers.contains("user2"));
+        Boolean isMember1 = redisTemplate.opsForSet().isMember("active-tokens", "user1");
+        Boolean isMember2 = redisTemplate.opsForSet().isMember("active-tokens", "user2");
+        assertEquals(Boolean.TRUE, isMember1);
+        assertEquals(Boolean.TRUE, isMember2);
+
+    }
+
+
+    @DisplayName("대기열 진입 후 순위 확인")
+    @Test
+    void GetWaitingRank() {
+        // given
+        String userId1 = "user1";
+        String userId2 = "user2";
+        queueService.addWaitingQueue(userId1);
+        queueService.addWaitingQueue(userId2);
+
+        // when
+        Long rank1 = queueService.getWaitingRank(userId1);
+        Long rank2 = queueService.getWaitingRank(userId2);
+
+        // then
+        assertEquals(1L, rank1);
+        assertEquals(2L, rank2);
+    }
+
+    @DisplayName("만료된 활성화 토큰 제거 확인")
+    @Test
+    void removeExpiredActiveQueue() throws InterruptedException {
+        // given
+        String userId = "user1";
+        queueService.addActiveQueue(userId, 1); // TTL을 1초로 설정
+        Thread.sleep(2000); // 키가 만료될 때까지 대기
+
+        // when
+        queueService.removeExpiredActiveQueue();
+
+        // then
+        Boolean isMember = redisTemplate.opsForSet().isMember("active-tokens", userId);
+        assertNotEquals(Boolean.TRUE, isMember);
+
+    }
+
+
+}


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

- [feat : redis 대기열 구현](https://github.com/youngy1212/Concert/pull/29/commits/8145cdb7e50d81953915e3ccde861305f6d82106)
- [feat : 대기열 controller 추가](https://github.com/youngy1212/Concert/pull/29/commits/1519b69c998e1b4c6f08d2f7535db17643a4ed4f)
- [test : redis 대기열 구현 test](https://github.com/youngy1212/Concert/pull/29/commits/b3b531221e9fd2fbef19ee0ce325f8972d7631f6)
- [test : 꺠진 테스트 변경](https://github.com/youngy1212/Concert/pull/29/commits/61c12d637dd6873979cdad033f17a45e56fe5644)

- [feat : 토큰 데이터 map 저장](https://github.com/youngy1212/Concert/pull/29/commits/665e9d1bc1ae2c427ed29103c33c603d3bf6be18)



---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1
현재 ACTIVE_TOKENS_KEY 자체에 TTL(Time To Live)을 설정할 수 없어, 데이터 정합성을 유지하기 위해 배치 프로세스를 돌렸습니다. 배치로 해결하는 것보다 더 좋은 방법이 있을까요? 카프카를 사용하는 것이 좋을까요? 또한, 대기열을 활성화하는 것도 카프카 이벤트를 이용하게 될까요? 다른 방법이 있다면 알고 싶습니다.
- 리뷰 포인트 2
ZSet userId 을 통해 대기열을 만들었습니다. 토큰 정보를 저장하기 위해 Hash을 만드니, Hash이 필요 없다는 생각이 들었습니다. 어떻게 변경하는게 좋을지 조언 부탁드립니다. 
제가 생각 한 방법 :   Zset도 tokenId를 사용하여, Zset, Hash 둘 다 사용, 아니면 Zset 하나로만 대기열 관리

<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->

### Problem
<!--개선이 필요한 점-->

### Try
<!-- 새롭게 시도할 점 -->