### PR TITLE
[STEP-17]  kafka test containers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,12 @@ dependencies {
 	implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 	implementation("com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.13.0")
 
+	//Kafka
+	implementation("org.apache.kafka:kafka-streams")
+	implementation("org.springframework.kafka:spring-kafka")
+	testImplementation("org.springframework.kafka:spring-kafka-test")
+	testImplementation("org.testcontainers:kafka")
+
 	// swagger
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,21 @@ services:
     volumes:
       - ./data/mysql/:/var/lib/mysql
 
+  kafka:
+    image: confluentinc/cp-kafka:7.8.1
+    ports:
+      - "9094:9094"
+    volumes:
+      - kafka-data:/kafka/data
+    environment:
+      KAFKA_CFG_NODE_ID: 0
+      KAFKA_CFG_PROCESS_ROLES: controller,broker
+      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 0@127.0.0.1:9093
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+
   redis:
     image: redis:6.2
     container_name: my-redis
@@ -23,6 +38,9 @@ services:
 
 volumes:
   redis-data:
+  kafka-zookeeper-data:
+  kafka-data:
+
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,12 @@ services:
     volumes:
       - ./data/mysql/:/var/lib/mysql
 
+  zookeeper:
+    image: zookeeper:latest
+    ports:
+      - "2181:2181"
+
+
   kafka:
     image: confluentinc/cp-kafka:7.8.1
     ports:
@@ -26,6 +32,9 @@ services:
       KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
       KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 0@127.0.0.1:9093
       KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9094
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
   redis:
     image: redis:6.2

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,7 +28,6 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
     consumer:
-      group-id: concert-consumer-group
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       auto-offset-reset: earliest

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,20 @@ spring:
     properties:
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+
+  kafka:
+    bootstrap-servers: localhost:9094
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    consumer:
+      group-id: concert-consumer-group
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+
 server:
   port: 8087
 
@@ -40,5 +54,7 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: none
+
+
 
 springdoc.override-with-generic-response: false

--- a/src/test/java/kr/hhplus/be/server/KafkaTestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/server/KafkaTestcontainersConfiguration.java
@@ -1,0 +1,30 @@
+package kr.hhplus.be.server;
+
+import jakarta.annotation.PreDestroy;
+import org.springframework.context.annotation.Configuration;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@Configuration
+public class KafkaTestcontainersConfiguration {
+
+    public static final ConfluentKafkaContainer KAFKA_CONTAINER;
+
+    static {
+        KAFKA_CONTAINER = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.8.1"));
+        KAFKA_CONTAINER.start();
+
+        System.setProperty("spring.kafka.bootstrap-servers", KAFKA_CONTAINER.getBootstrapServers());
+        System.setProperty("spring.kafka.consumer.bootstrap-servers", KAFKA_CONTAINER.getBootstrapServers());
+        System.setProperty("spring.kafka.producer.bootstrap-servers", KAFKA_CONTAINER.getBootstrapServers());
+    }
+
+    @PreDestroy
+    public void preDestroy() {
+        if (KAFKA_CONTAINER.isRunning()) {
+            KAFKA_CONTAINER.stop();
+        }
+    }
+}
+
+

--- a/src/test/java/kr/hhplus/be/server/interfaces/kafka/KafkaTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/kafka/KafkaTest.java
@@ -1,0 +1,50 @@
+package kr.hhplus.be.server.interfaces.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+@ActiveProfiles("test")
+public class KafkaTest {
+
+    private final String topic = "test-topic";
+
+    private AtomicInteger atomicInteger = new AtomicInteger();
+
+    @Autowired
+    private KafkaTemplate<Object, Object> kafkaTemplate;
+
+
+    @KafkaListener(topics = topic,groupId = "test-group")
+    void testListener(String message) {
+        atomicInteger.incrementAndGet();
+    }
+
+    @DisplayName("카프카 테스트컨테이너로 연결 테스트")
+    @Test
+    void KafkaConnectTest() {
+        kafkaTemplate.send(topic,"Hello, Kafka!");
+        await()
+                .pollInterval(Duration.ofMillis(300))
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertThat(atomicInteger.get()).isEqualTo(1);
+                });
+    }
+
+
+}
+


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

- 카프카 세팅
[init : kafka setting](https://github.com/youngy1212/Concert/pull/36/commits/b11e85fa32b8e43b03031fc14b4c1e67c98a5302)
[init : kafka testcontainers config](https://github.com/youngy1212/Concert/pull/36/commits/ac4baedcf414d58abee676b7babeed31a600c774)

- 카프카 연결 테스트
[test : kafka 연결 테스트](https://github.com/youngy1212/Concert/pull/36/commits/4b72ea1b68dbbc62e69ca0de4beb95649e58d670)

---
### **리뷰 포인트(질문)**
- bitnami/kafka:3.5.1 처음에는 이걸로 주키퍼 없이 올렸다가 자꾸 테스트 컨터이너 오류가나서 (버전 충돌?), confluentinc/cp-kafka:7.8.1로 변경하였습니다. 그러니 주키퍼가 없으면 다운되더라고요. 찾아보니 Confluent  이미지가 기본적으로 주키퍼를 필요로해서 그런 것 같습니다.
-> 이런 호환 문제나, 버전 충돌 문제를 효과적으로 대응할 수 있는 꿀팁이 있을까요...? 
- 
<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->

### Problem
<!--개선이 필요한 점-->

### Try
<!-- 새롭게 시도할 점 -->